### PR TITLE
Feat/task completion

### DIFF
--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -78,6 +78,7 @@ const computedStatusClass: ComputedRef<string> = computed(() => {
 .item--complete {
   color: #888;
   transition: none;
+  text-decoration: line-through;
 }
 
 .item--complete :deep(svg),

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -1,32 +1,66 @@
 <script setup lang="ts">
-import {ref} from 'vue'
-import {Item} from "../pages/Daily.vue";
+import {ComputedRef, Ref, ref, computed} from 'vue'
+import {Item} from "@/pages/Daily.vue";
 import UncheckedBox from "@icons/UncheckedBox.vue";
 import CheckedBox from "@icons/CheckedBox.vue";
 import Star from "@icons/Star.vue";
 import StarFilled from "@icons/StarFilled.vue";
+import {useItemsStore} from "@/store/items";
+
+const itemsStore = useItemsStore();
 
 interface Props {
-  item: Item
+  item: Item,
 }
 
 const props = defineProps<Props>();
+
+const switching: Ref<boolean> = ref(false);
+const hovering: Ref<boolean> = ref(false);
+
+function handleCheckboxClick() {
+  switching.value = true;
+
+  setTimeout(() => {
+    itemsStore.toggleItemCompletion(props.item);
+    switching.value = false;
+  }, 300)
+
+}
+
+const showUncheckedBox: ComputedRef<boolean> = computed(() => {
+  if (props.item.status === 'incomplete') {
+    return !hovering.value && !switching.value;
+  }
+  if (props.item.status === 'complete') {
+    return hovering.value || switching.value;
+  }
+  return false;
+})
+
+const computedStatusClass: ComputedRef<string> = computed(() => {
+  return "item--" + props.item.status;
+})
+
 
 </script>
 
 <template>
   <li
       class="list__item"
-      :class="{
-      'item--incomplete' : item.status === 'incomplete',
-      'item--complete' : item.status === 'complete',
-      'item--migrated' : item.status === 'migrated',
-      'item--cancelled' : item.status === 'cancelled',
-    }"
+      :class="[
+        computedStatusClass,
+        {
+          'item--switching' : switching
+        }
+      ]"
   >
     <div class="list__item__bullet">
-      <UncheckedBox v-if="item.status === 'incomplete'" :color="'#333'"/>
-      <CheckedBox v-if="item.status === 'complete'" :color="'#888'"/>
+      <button class="bullet__button" @click="handleCheckboxClick" @mouseover="hovering = true"
+              @mouseleave="hovering = false">
+        <UncheckedBox v-if="showUncheckedBox"/>
+        <CheckedBox v-else/>
+      </button>
     </div>
     <div class="list__item__content">
       <p class="my-0">{{ item.text }}</p>
@@ -43,6 +77,7 @@ const props = defineProps<Props>();
 <style scoped>
 .item--complete {
   color: #888;
+  transition: none;
 }
 
 .item--complete :deep(svg),
@@ -55,15 +90,20 @@ const props = defineProps<Props>();
   fill: #333;
 }
 
-li {
-  text-align: left;
-}
-
-li::marker {
-  content: inherit;
+.bullet__button {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  background: transparent;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .list__item {
+  opacity: 1;
+  text-align: left;
   list-style: none;
   display: flex;
   align-items: flex-start;
@@ -71,11 +111,16 @@ li::marker {
   width: 100%;
 }
 
+.list__item.item--switching {
+  opacity: 0;
+  transition: all 0.3s;
+}
+
 .list__item__bullet {
-  font-size: 1.5rem;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
+  font-size: 1.25rem;
+  height: 100%;
+  width: 1.25rem;
+  min-width: 1.25rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -83,7 +128,7 @@ li::marker {
 }
 
 .list__item__bullet > span {
-  height: 1.5rem;
+  height: 1.25rem;
   width: max-content;
   display: flex;
   flex-direction: column;

--- a/src/store/items.ts
+++ b/src/store/items.ts
@@ -32,6 +32,18 @@ export const useItemsStore = defineStore('items', () => {
         return data.sort(compareImportance).sort(compareStatuses);
     }
 
+    function toggleItemCompletion(paramItem: Item) {
+        console.log(paramItem.status);
+        let newStatus: String;
+        if (paramItem.status === 'complete') {
+            newStatus = 'incomplete';
+        } else if (paramItem.status === 'incomplete') {
+            newStatus = 'complete';
+        }
+        items.value = items.value.map(item =>
+            (item.id === paramItem.id) ? {...item, status: newStatus} : item);
+
+    }
 
     function fetchItems() {
         items.value = itemSorter(data.data);
@@ -41,5 +53,5 @@ export const useItemsStore = defineStore('items', () => {
         return itemSorter(items.value)
     })
 
-    return {items, fetchItems, sortedItems};
+    return {items, fetchItems, sortedItems, toggleItemCompletion};
 })


### PR DESCRIPTION
Checkbox is now a button that handles click events to trigger the toggleItemCompletion action in the items store. 

When you hover over an unchecked box, a checked box will appear to preview the toggling of states. Then when you click, there is a "completing" boolean set to true to indicate a transition state. The box will be checked and stay in position for half a second (this prevents a ui behavior that may be too jarring). After a 500ms timeout, the store action is triggered to switch the status from incomplete to complete. Selected task will fade out then be re-rendered towards the bottom of the list where the completed tasks are. Completed task will have a checked box, be slightly greyed out, and have a strikethrough. You can then click the checked box again to change the complete status to incomplete and the inverse effects will take place.