### PR TITLE
Feat/task editing

### DIFF
--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {ComputedRef, Ref, ref, computed} from 'vue'
+import {ComputedRef, Ref, ref, computed, nextTick} from 'vue'
 import {Item} from "@/pages/Daily.vue";
 import UncheckedBox from "@icons/UncheckedBox.vue";
 import CheckedBox from "@icons/CheckedBox.vue";

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -61,6 +61,32 @@ function handleImportantClick() {
 
 }
 
+async function startEditing() {
+    if (props.item.status !== 'incomplete' || editing.value) return;
+    editing.value = true;
+    await nextTick();
+    if (TaskText.value) {
+        setCaratToEnd(TaskText.value);
+        TaskText.value?.focus();
+    }
+}
+
+function setCaratToEnd(element: HTMLElement) {
+    // Place cursor at the end of a content editable div
+    if (element.getAttribute("contenteditable") === "true") {
+        element.focus();
+        window?.getSelection()?.selectAllChildren(element);
+        window?.getSelection()?.collapseToEnd();
+    }
+}
+
+function cancelEdit() {
+    editing.value = false;
+    if (TaskText.value) {
+        TaskText.value.textContent = props.item.text;
+    }
+}
+
 const showUncheckedBox: ComputedRef<boolean> = computed(() => {
     if (props.item.status === 'incomplete') {
         return !hovering.value && !switching.value;

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -190,6 +190,10 @@ const computedStatusClass: ComputedRef<string> = computed(() => {
     fill: #999;
 }
 
+.list__item__text > p {
+    padding: 2px 4px;
+}
+
 .list__item {
     opacity: 1;
     text-align: left;

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -108,34 +108,53 @@ const computedStatusClass: ComputedRef<string> = computed(() => {
     <li
       class="list__item"
       :class="[
-        computedStatusClass,
-        {
-          'item--switching' : switching,
-          'item--important-switching' : importantSwitching
-        }
-      ]"
-  >
-    <div class="list__item__bullet">
-      <button class="bullet__button" @click="handleCheckboxClick" @mouseover="hovering = true"
-              @mouseleave="hovering = false">
-        <UncheckedBox v-if="showUncheckedBox"/>
-        <CheckedBox v-else/>
-      </button>
-    </div>
-    <div class="list__item__content">
-      <p class="my-0">{{ item.text }}</p>
-      <p v-if="item.status === 'migrated'" class="my-0 list__item__subtext">Moved to Apr 30</p>
-      <p v-if="item.status === 'cancelled'" class="my-0 list__item__subtext">Cancelled</p>
-    </div>
-    <div class="list__item__signifier">
-      <button class="signifier__button" @click="handleImportantClick" @mouseover="importantHovering = true"
-              @mouseleave="importantHovering = false">
-        <Star v-if="!item.important && !importantHovering"/>
-        <StarFilled v-else/>
-
-      </button>
-    </div>
-  </li>
+      computedStatusClass,
+      {
+        'item--switching' : switching,
+        'item--important-switching' : importantSwitching
+      }
+    ]"
+    >
+        <div class="list__item__bullet">
+            <button
+              class="bullet__button"
+              @click="handleCheckboxClick"
+              @mouseover="hovering = true"
+              @mouseleave="hovering = false"
+            >
+                <UncheckedBox v-if="showUncheckedBox"/>
+                <CheckedBox v-else/>
+            </button>
+        </div>
+        <div class="list__item__content">
+            <div class="list__item__text">
+                <p
+                  class="my-0"
+                  :contenteditable="editing"
+                  @click="startEditing"
+                  @keydown.enter.prevent="handleInputSubmit($event)"
+                  @keydown.esc.prevent="cancelEdit"
+                  v-click-outside="cancelEdit"
+                  ref="TaskText"
+                >
+                    {{ item.text }}
+                </p>
+            </div>
+            <p v-if="item.status === 'migrated'" class="my-0 list__item__subtext">Moved to Apr 30</p>
+            <p v-if="item.status === 'cancelled'" class="my-0 list__item__subtext">Cancelled</p>
+        </div>
+        <div class="list__item__signifier">
+            <button
+              class="signifier__button"
+              @click="handleImportantClick"
+              @mouseover="importantHovering = true"
+              @mouseleave="importantHovering = false"
+            >
+                <Star v-if="!item.important && !importantHovering"/>
+                <StarFilled v-else/>
+            </button>
+        </div>
+    </li>
 </template>
 
 <style scoped>

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -52,23 +52,23 @@ function handleInputSubmit(event: Event) {
 }
 
 function handleImportantClick() {
-  importantSwitching.value = true;
+    importantSwitching.value = true;
 
-  setTimeout(() => {
-    itemsStore.toggleItemImportance(props.item);
-    importantSwitching.value = false;
-  }, 300)
+    setTimeout(() => {
+        itemsStore.toggleItemImportance(props.item);
+        importantSwitching.value = false;
+    }, 300)
 
 }
 
 const showUncheckedBox: ComputedRef<boolean> = computed(() => {
-  if (props.item.status === 'incomplete') {
-    return !hovering.value && !switching.value;
-  }
-  if (props.item.status === 'complete') {
-    return hovering.value || switching.value;
-  }
-  return false;
+    if (props.item.status === 'incomplete') {
+        return !hovering.value && !switching.value;
+    }
+    if (props.item.status === 'complete') {
+        return hovering.value || switching.value;
+    }
+    return false;
 })
 
 const computedStatusClass: ComputedRef<string> = computed(() => {
@@ -79,7 +79,7 @@ const computedStatusClass: ComputedRef<string> = computed(() => {
 </script>
 
 <template>
-  <li
+    <li
       class="list__item"
       :class="[
         computedStatusClass,
@@ -131,28 +131,28 @@ const computedStatusClass: ComputedRef<string> = computed(() => {
 
 .bullet__button,
 .signifier__button {
-  width: 100%;
-  height: 100%;
-  padding: 0;
-  background: transparent;
-  border: none;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    background: transparent;
+    border: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .signifier__button:hover :deep(svg) {
-  fill: #999;
+    fill: #999;
 }
 
 .list__item {
-  opacity: 1;
-  text-align: left;
-  list-style: none;
-  display: flex;
-  align-items: flex-start;
-  margin: 0.3rem 0;
-  width: 100%;
+    opacity: 1;
+    text-align: left;
+    list-style: none;
+    display: flex;
+    align-items: flex-start;
+    margin: 0.3rem 0;
+    width: 100%;
 }
 
 .list__item.item--switching,
@@ -162,14 +162,15 @@ const computedStatusClass: ComputedRef<string> = computed(() => {
 }
 
 .list__item__bullet {
-  font-size: 1.25rem;
-  height: 100%;
-  width: 1.25rem;
-  min-width: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
+    font-size: 1.25rem;
+    height: 100%;
+    width: 1.25rem;
+    min-width: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    margin-top: 3px;
 }
 
 .list__item__bullet > span {

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -21,6 +21,9 @@ const hovering: Ref<boolean> = ref(false);
 const importantSwitching: Ref<boolean> = ref(false);
 const importantHovering: Ref<boolean> = ref(false);
 
+const editing: Ref<boolean> = ref(false);
+const TaskText = ref<HTMLParagraphElement | null>(null);
+
 function handleCheckboxClick() {
   switching.value = true;
 

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -34,6 +34,23 @@ function handleCheckboxClick() {
 
 }
 
+function handleInputSubmit(event: Event) {
+    event.preventDefault();
+    const target = event.target as HTMLParagraphElement;
+    if (target.textContent) {
+        if (!target.textContent.length) {
+            return;
+        }
+    }
+    const newText = target.textContent;
+    const newItem = props.item;
+    newItem.text = newText;
+    itemsStore.updateItemText(newItem);
+    if (TaskText.value) {
+        TaskText.value?.blur();
+    }
+}
+
 function handleImportantClick() {
   importantSwitching.value = true;
 

--- a/src/components/TaskList/Task.vue
+++ b/src/components/TaskList/Task.vue
@@ -10,7 +10,7 @@ import {useItemsStore} from "@/store/items";
 const itemsStore = useItemsStore();
 
 interface Props {
-  item: Item,
+    item: Item,
 }
 
 const props = defineProps<Props>();
@@ -25,12 +25,12 @@ const editing: Ref<boolean> = ref(false);
 const TaskText = ref<HTMLParagraphElement | null>(null);
 
 function handleCheckboxClick() {
-  switching.value = true;
+    switching.value = true;
 
-  setTimeout(() => {
-    itemsStore.toggleItemCompletion(props.item);
-    switching.value = false;
-  }, 300)
+    setTimeout(() => {
+        itemsStore.toggleItemCompletion(props.item);
+        switching.value = false;
+    }, 300)
 
 }
 

--- a/src/store/items.ts
+++ b/src/store/items.ts
@@ -51,6 +51,16 @@ export const useItemsStore = defineStore('items', () => {
 
     }
 
+    // Takes an input item
+    // Maps through the array
+    // If parameter item id matches current item id, it will update the item using spread
+    // Else just return the item back
+    function updateItemText(paramItem: Item) {
+        items.value = items.value.map(item =>
+            (item.id === paramItem.id) ? {...item, text: paramItem.text} : item);
+
+    }
+
     function fetchItems() {
         items.value = itemSorter(data.data);
     }
@@ -59,5 +69,5 @@ export const useItemsStore = defineStore('items', () => {
         return itemSorter(items.value)
     })
 
-    return {items, fetchItems, sortedItems, toggleItemCompletion, toggleItemImportance};
+    return {items, fetchItems, sortedItems, toggleItemCompletion, toggleItemImportance, updateItemText};
 })


### PR DESCRIPTION
Feature: Tasks are now editable

When you click on the text of a task,, the paragraph element becomes contenteditable, focused, and the carat is set to the end. Then you start to edit and move the carat around the text. To save/update, hit enter. To cancel, click outside or press escape.

When a task is being edited, the paragraph will have a border around it to indicate. If the new text content is empty, submitting is prevented.