### PR TITLE
Feat/router updates

### DIFF
--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -23,7 +23,7 @@
                   class="drawer__navigation__list__item drawer__navigation__list__item--active"
                   @click="closeDrawer"
           >
-              <router-link to="/daily/1">Today</router-link>
+              <router-link to="/daily/today">Today</router-link>
           </li>
           <li
                   class="drawer__navigation__list__item"

--- a/src/pages/Daily.vue
+++ b/src/pages/Daily.vue
@@ -48,24 +48,27 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="container">
-    <div class="daily-view">
-      <div class="daily-view__header">
-        <button @click="openDrawer()" class="daily-view__header__button button--text button--left">&#9776;</button>
-      </div>
-      <div class="daily-view__content">
-          <h2 class="daily-view__title">{{ date.toLocaleString('default', {month: 'short'}) }} {{ date.getDate() }}</h2>
-          <div class="daily-view__list">
-              <List :items="itemsStore.getDayItems( date )"></List>
-              <AddTask :day="date"></AddTask>
-          </div>
-      </div>
-      <div class="daily__paginator">
-        <button class="button--text button--left"><span>&lt; Apr 5</span></button>
-        <button class="button--text button--right"><span>Apr 7 &gt;</span></button>
-      </div>
+    <div class="container">
+        <div class="daily-view">
+            <div class="daily-view__header">
+                <button @click="openDrawer()" class="daily-view__header__button button--text button--left">&#9776;
+                </button>
+            </div>
+            <div class="daily-view__content" v-if="date">
+                <h2 class="daily-view__title">{{ date.toLocaleString('default', {month: 'short'}) }} {{
+                        date.getDate()
+                    }}</h2>
+                <div class="daily-view__list">
+                    <List :items="items"></List>
+                    <AddTask :day="date"></AddTask>
+                </div>
+            </div>
+            <div class="daily__paginator">
+                <button class="button--text button--left"><span>&lt; Apr 5</span></button>
+                <button class="button--text button--right"><span>Apr 7 &gt;</span></button>
+            </div>
+        </div>
     </div>
-  </div>
 </template>
 
 <style scoped>

--- a/src/pages/Daily.vue
+++ b/src/pages/Daily.vue
@@ -8,6 +8,9 @@ import AddTask from "@components/TaskList/AddTask.vue";
 
 import { useItemsStore } from "../store/items";
 const itemsStore = useItemsStore();
+import {useRoute} from 'vue-router'
+
+const route = useRoute();
 
 export interface Item {
   id: string;

--- a/src/pages/Daily.vue
+++ b/src/pages/Daily.vue
@@ -39,7 +39,10 @@ function setDate() {
 }
 
 onMounted(() => {
-  itemsStore.fetchItems();
+    setDate();
+    if (date.value) {
+        items.value = itemsStore.getDayItems(date.value)
+    }
 })
 
 </script>

--- a/src/pages/Daily.vue
+++ b/src/pages/Daily.vue
@@ -24,7 +24,19 @@ function openDrawer() {
     drawerStore.drawer = true;
 }
 
-const date: Ref<Date> = ref(new Date);
+const items: Ref<Item[]> = ref([]);
+
+const date: Ref<Date | null> = ref(null);
+
+function setDate() {
+    const {day, month, year} = route.params;
+    if (day === "today") {
+        date.value = new Date;
+    } else {
+        const dateString = month + "/" + day + "/" + year;
+        date.value = new Date(dateString);
+    }
+}
 
 onMounted(() => {
   itemsStore.fetchItems();

--- a/src/pages/Daily.vue
+++ b/src/pages/Daily.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {computed, onMounted, ref} from 'vue'
-import type { Ref } from 'vue';
+import type {Ref} from 'vue';
 import List from "../components/List.vue";
 import {useDrawerStore} from "../store/drawer";
 const drawerStore = useDrawerStore();
@@ -13,15 +13,15 @@ import {useRoute} from 'vue-router'
 const route = useRoute();
 
 export interface Item {
-  id: string;
-  text: string,
-  status: string,
-  type: string,
-  important: boolean
+    id: string;
+    text: string,
+    status: string,
+    type: string,
+    important: boolean
 }
 
 function openDrawer() {
-  drawerStore.drawer = true;
+    drawerStore.drawer = true;
 }
 
 const date: Ref<Date> = ref(new Date);

--- a/src/pages/Weekly.vue
+++ b/src/pages/Weekly.vue
@@ -36,7 +36,7 @@ const monthNames = ["January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
 ];
 
-const dayNamesShort = ["Sun", "Mon", "Tue", "Wed", "Thur", "Fri", "Sat"];
+const dayNamesShort = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 const monthName = () => {
     return monthNames[date.value.getMonth()];

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,7 @@ const routes = [
         component: index,
     },
     {
-        path: '/daily/:id',
+        path: '/daily/:day/:month?/:year?',
         component: Daily
     },
     {

--- a/src/store/items.ts
+++ b/src/store/items.ts
@@ -52,6 +52,8 @@ export const useItemsStore = defineStore('items', () => {
             return itemDateString === paramDateString;
         }
 
+        fetchItems();
+
         const dayItems = items.value.filter(sameDate);
         return itemSorter(dayItems);
     }

--- a/src/store/items.ts
+++ b/src/store/items.ts
@@ -46,15 +46,6 @@ export const useItemsStore = defineStore('items', () => {
     }
 
     function getDayItems(paramDate: Date) {
-        // console.log(day);
-        // console.log(day.getDate());
-        // items.value.forEach(item => {
-        //     const itemDate = new Date(item.date);
-        //     console.log("item date: ",itemDate.toDateString());
-        //     console.log("param date: ", paramDate.toDateString());
-        // })
-
-
         function sameDate(item: Item) {
             const itemDateString = new Date(item.date).toDateString();
             const paramDateString = paramDate.toDateString();


### PR DESCRIPTION
### Some basic router updates

Added params to daily path: day, month, year. Month and year are optional
New path: /daily/:day/:month?/:year?
Route params are now used in the daily page. If day === 'today', then the date ref is set to today and we can use that to get all items with a matching date. If not, then use the day, month, and year params to construct a new string and get a new Date using that. Same thing, this new date ref value is now used as the filter for items.

